### PR TITLE
feat: Add Support for Rejecting Unlisted 7TV Emotes

### DIFF
--- a/models/src/reward.rs
+++ b/models/src/reward.rs
@@ -78,11 +78,28 @@ pub struct TimeoutRewardData {
 pub struct SlotRewardData {
     pub slots: usize,
     pub expiration: String,
+    #[serde(default = "always_true")]
+    pub allow_unlisted: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SwapRewardData {
     pub limit: Option<u8>,
+    #[serde(default = "always_true")]
+    pub allow_unlisted: bool,
+}
+
+impl Default for SwapRewardData {
+    fn default() -> Self {
+        Self {
+            limit: Default::default(),
+            allow_unlisted: true,
+        }
+    }
+}
+
+const fn always_true() -> bool {
+    true
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/services/emotes/bttv.rs
+++ b/src/services/emotes/bttv.rs
@@ -45,6 +45,7 @@ impl EmoteRW for BttvEmotes {
     async fn get_check_initial_data(
         broadcaster_id: &str,
         emote_id: &str,
+        _allow_unlisted: bool,
         pool: &PgPool,
     ) -> AnyResult<EmoteInitialData<String, bttv::BttvEmote>> {
         let (bttv_id, history_len) = futures::future::try_join(

--- a/src/services/emotes/ffz.rs
+++ b/src/services/emotes/ffz.rs
@@ -46,6 +46,7 @@ impl EmoteRW for FfzEmotes {
     async fn get_check_initial_data(
         broadcaster_id: &str,
         emote_id: &str,
+        _allow_unlisted: bool,
         pool: &PgPool,
     ) -> AnyResult<EmoteInitialData<usize, ffz::FfzEmote>> {
         let (ffz_user, ffz_emote, ffz_room, ffz_history) =

--- a/src/services/emotes/mod.rs
+++ b/src/services/emotes/mod.rs
@@ -51,6 +51,7 @@ pub trait EmoteRW {
     async fn get_check_initial_data(
         broadcaster_id: &str,
         emote_id: &str,
+        allow_unlisted: bool,
         pool: &PgPool,
     ) -> AnyResult<EmoteInitialData<Self::PlatformId, Self::Emote>>;
     async fn get_emote_env_data(

--- a/src/services/emotes/seven_tv.rs
+++ b/src/services/emotes/seven_tv.rs
@@ -39,6 +39,7 @@ impl EmoteRW for SevenTvEmotes {
     async fn get_check_initial_data(
         broadcaster_id: &str,
         emote_id: &str,
+        allow_unlisted: bool,
         pool: &PgPool,
     ) -> AnyResult<EmoteInitialData<Self::PlatformId, Self::Emote>> {
         let (history_len, emote, stv_user) = futures::future::try_join3(
@@ -59,6 +60,12 @@ impl EmoteRW for SevenTvEmotes {
         {
             return Err(AnyError::msg(
                 "The emote or an emote with the same name already exists.",
+            ));
+        }
+
+        if !allow_unlisted && !emote.listed {
+            return Err(AnyError::msg(
+                "Attempted to add an unlisted emote, but unlisted emotes aren't allowed.",
             ));
         }
 

--- a/src/services/emotes/slots.rs
+++ b/src/services/emotes/slots.rs
@@ -162,8 +162,13 @@ where
         .into_iter()
         .next()
         .ok_or_else(|| AnyError::msg("No free slot is available!"))?;
-    let emote_data =
-        RW::get_check_initial_data(broadcaster_id, emote_id, pool).await?;
+    let emote_data = RW::get_check_initial_data(
+        broadcaster_id,
+        emote_id,
+        slot_data.allow_unlisted,
+        pool,
+    )
+    .await?;
 
     if emote_data.current_emotes >= emote_data.max_emotes {
         return Err(AnyError::msg("There's no free slot!"));

--- a/src/services/emotes/swap.rs
+++ b/src/services/emotes/swap.rs
@@ -28,8 +28,13 @@ where
     {
         return Err(AnyError::msg("This emote is banned"));
     }
-    let data =
-        RW::get_check_initial_data(broadcaster_id, emote_id, pool).await?;
+    let data = RW::get_check_initial_data(
+        broadcaster_id,
+        emote_id,
+        reward_data.allow_unlisted,
+        pool,
+    )
+    .await?;
     let removed_emote = if data.current_emotes >= data.max_emotes
         || reward_data
             .limit

--- a/src/services/seven_tv/requests.rs
+++ b/src/services/seven_tv/requests.rs
@@ -64,6 +64,8 @@ struct SevenEmoteResponse {
 pub struct SevenEmote {
     pub name: String,
     pub id: String,
+    #[serde(default)]
+    pub listed: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -129,7 +131,7 @@ pub async fn get_emote(emote_id: &str) -> AnyResult<SevenEmote> {
     let emote = seven_tv_post::<SevenEmoteResponse>(
         "https://7tv.io/v3/gql",
         &GqlRequest {
-            query: "query($id: ObjectID!) { emote(id: $id) { id, name } }",
+            query: "query($id: ObjectID!) { emote(id: $id) { id, name, listed } }",
             variables: GqlIdVars { id: emote_id },
         },
     )

--- a/web/src/api/rewards-data.ts
+++ b/web/src/api/rewards-data.ts
@@ -31,19 +31,19 @@ export const StaticRewardData: { [K in keyof RewardDataMap]: StaticData<K> } = {
     display: 'Add/Swap Bttv Emote',
     inputRequired: true,
     validOptions: emoteSwapValid,
-    defaultOptions: { limit: null },
+    defaultOptions: { limit: null, allow_unlisted: true },
   },
   FfzSwap: {
     display: 'Add/Swap Ffz Emote',
     inputRequired: true,
     validOptions: emoteSwapValid,
-    defaultOptions: { limit: null },
+    defaultOptions: { limit: null, allow_unlisted: true },
   },
   SevenTvSwap: {
     display: 'Add/Swap 7TV Emote',
     inputRequired: true,
     validOptions: emoteSwapValid,
-    defaultOptions: { limit: null },
+    defaultOptions: { limit: null, allow_unlisted: true },
   },
   BttvSlot: {
     display: 'Bttv Slots',
@@ -52,6 +52,7 @@ export const StaticRewardData: { [K in keyof RewardDataMap]: StaticData<K> } = {
     defaultOptions: {
       slots: 2,
       expiration: '2d',
+      allow_unlisted: true,
     },
   },
   FfzSlot: {
@@ -61,6 +62,7 @@ export const StaticRewardData: { [K in keyof RewardDataMap]: StaticData<K> } = {
     defaultOptions: {
       slots: 2,
       expiration: '2d',
+      allow_unlisted: true,
     },
   },
   SevenTvSlot: {
@@ -70,6 +72,7 @@ export const StaticRewardData: { [K in keyof RewardDataMap]: StaticData<K> } = {
     defaultOptions: {
       slots: 2,
       expiration: '2d',
+      allow_unlisted: true,
     },
   },
   SpotifySkip: {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -107,10 +107,12 @@ export interface TimeoutRewardData {
 export interface SlotRewardData {
   slots: number;
   expiration: string;
+  allow_unlisted?: boolean;
 }
 
 export interface SwapRewardData {
   limit: number | null;
+  allow_unlisted?: boolean;
 }
 
 export interface SpotifyPlayOptions {

--- a/web/src/components/core/CSwitch.vue
+++ b/web/src/components/core/CSwitch.vue
@@ -38,7 +38,7 @@ export default defineComponent({
   emits: ['update:modelValue'],
   setup(_, { emit }) {
     const onUpdate = (v: boolean) => {
-      emit('update:modelValue', v);
+      emit('update:modelValue', !!v);
     };
     return { onUpdate };
   },

--- a/web/src/components/rewards/EmoteSlotSettings.vue
+++ b/web/src/components/rewards/EmoteSlotSettings.vue
@@ -1,11 +1,13 @@
 <template>
   <CSlider v-model="state.slots" label="Slots" :min="1" :max="10" />
   <TextField v-model="state.expiration" label="Expiration" />
+  <CSwitch v-model="state.allow_unlisted" label="Allow unlisted emotes" />
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType, reactive, toRefs, watch } from 'vue';
 import CSlider from '../core/CSlider.vue';
+import CSwitch from '../core/CSwitch.vue';
 import { SlotRewardData } from '../../api/types';
 import TextField from '../core/TextField.vue';
 
@@ -27,6 +29,7 @@ export default defineComponent({
     watch(modelValue, newValue => {
       state.expiration = newValue.expiration;
       state.slots = newValue.slots;
+      state.allow_unlisted = newValue.allow_unlisted;
     });
     watch(state, value => {
       emit('update:modelValue', value);

--- a/web/src/components/rewards/EmoteSwapSettings.vue
+++ b/web/src/components/rewards/EmoteSwapSettings.vue
@@ -1,6 +1,8 @@
 <template>
   <CSwitch :model-value="sliderEnabled" label="Limit emotes" @update:model-value="updateSliderEnabled" />
   <CSlider v-if="state.limit !== null" v-model="state.limit" class="mt-2" :min="1" :max="100" />
+  <!-- TODO: fix this (xd) -->
+  <CSwitch v-model="state.allow_unlisted" label="Allow unlisted emotes" />
 </template>
 
 <script lang="ts">
@@ -22,7 +24,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const { modelValue } = toRefs(props);
 
-    const state = reactive(modelValue.value ?? { limit: null });
+    const state = reactive(modelValue.value ?? { limit: null, allow_unlisted: true });
     const sliderEnabled = computed(() => state.limit !== null);
     const updateSliderEnabled = (enabled: boolean) => {
       // set the "default" to 1
@@ -31,6 +33,7 @@ export default defineComponent({
 
     watch(modelValue, newValue => {
       state.limit = newValue?.limit ?? null;
+      state.allow_unlisted = newValue?.allow_unlisted ?? true;
     });
     watch(state, value => {
       emit('update:modelValue', value);


### PR DESCRIPTION
Adds support for rejecting unlisted 7TV emotes through a new option. The option is shown for all reward types currently, but only 7TV supports it right now.

Closes #104.