### PR TITLE
fix: add more cache to 7tv

### DIFF
--- a/src/services/emotes/bttv.rs
+++ b/src/services/emotes/bttv.rs
@@ -51,6 +51,7 @@ impl EmoteRW for BttvEmotes {
         overwritten_name: Option<&str>,
         _allow_unlisted: bool,
         pool: &PgPool,
+        _redis_pool: &RedisPool,
     ) -> AnyResult<EmoteInitialData<String, bttv::BttvEmote>> {
         if overwritten_name.is_some() {
             return Err(anyhow!("BTTV doesn't support renaming emotes"));

--- a/src/services/emotes/ffz.rs
+++ b/src/services/emotes/ffz.rs
@@ -52,6 +52,7 @@ impl EmoteRW for FfzEmotes {
         overwritten_name: Option<&str>,
         _allow_unlisted: bool,
         pool: &PgPool,
+        _redis_pool: &RedisPool,
     ) -> AnyResult<EmoteInitialData<usize, ffz::FfzEmote>> {
         if overwritten_name.is_some() {
             return Err(anyhow!("FFZ doesn't support renaming emotes"));

--- a/src/services/emotes/mod.rs
+++ b/src/services/emotes/mod.rs
@@ -56,6 +56,7 @@ pub trait EmoteRW {
         overwritten_name: Option<&str>,
         allow_unlisted: bool,
         pool: &PgPool,
+        redis_pool: &RedisPool,
     ) -> AnyResult<EmoteInitialData<Self::PlatformId, Self::Emote>>;
     async fn get_emote_env_data(
         broadcaster_id: &str,

--- a/src/services/emotes/slots.rs
+++ b/src/services/emotes/slots.rs
@@ -186,6 +186,7 @@ where
         override_name,
         slot_data.allow_unlisted,
         pool,
+        redis_pool,
     )
     .await?;
 

--- a/src/services/emotes/swap.rs
+++ b/src/services/emotes/swap.rs
@@ -41,6 +41,7 @@ where
         override_name,
         reward_data.allow_unlisted,
         pool,
+        redis_pool,
     )
     .await?;
 


### PR DESCRIPTION
Add more cache to 7TV stuff.

Regarding https://github.com/Nerixyz/rewards/issues/156. I don't think this is ideal but should do a better job. Removals are cached for 10 min.